### PR TITLE
Add travel, rest, creep, and fix delay

### DIFF
--- a/src/Actions.cpp
+++ b/src/Actions.cpp
@@ -4,7 +4,9 @@
 
 const std::vector<std::string> admin = {
     "quit",
-    "pray"
+    "sc", "score",
+    "stats",
+    "i", "items"
 };
 
 const std::vector<std::string> movement = {
@@ -16,16 +18,17 @@ const std::vector<std::string> movement = {
     "nw", "northwest",
     "se", "southeast",
     "sw", "southwest",
-    "m", "move"
+    "m", "move",
+    "tr", "travel"
 };
 
 const std::vector<std::string> action = {
-    "k", "kill",
-    "h", "hunt",
     "quest",
     "r", "rest",
-    "b", "buy",
-    "sell"
+    "st", "stand",
+    "buy",
+    "sell",
+    "creep"
 };
 
 const std::vector<std::string> skill = {

--- a/src/Character.h
+++ b/src/Character.h
@@ -21,13 +21,16 @@ public:
 
     const std::string& GetName() const { return _name; }
     void SetName(const std::string& name) { _name = name; }
-    void SetDelay(uint16_t delay) { _delay = delay; }
+    void SetDelay(uint16_t delay) { _delay = delay; printf("Set delay to %hu\n", _delay); }
+    uint16_t GetDelay() const { return _delay; }
+    void DecrementDelay() { if (_delay > 0) --_delay; }
     Location GetLocation() const { return _location; }
     void SetLocation(Location loc) { _location = loc; }
     const Zone& GetZone() const { return _world->GetZone(_location.major); }
     uint8_t GetSpeed() const { return _speed; } // Implement logic in the future
     // In case of player re-connection, must re-map new connection's buffer to character.
     void MapToConnection(size_t id, std::string* output) { _id = id; _output = output; }
+    bool HasConqueredZone(Coordinates zone) const;
 
 private:
     void DoAdmin(const std::vector<std::string>& tokens);
@@ -35,6 +38,7 @@ private:
     void DoMove(const std::vector<std::string>& tokens);
     bool Move(const std::string& first, const std::string& second);
     bool Move(Direction direction);
+    bool DoTravel(Direction direction);
 
     void DoActivity(const std::vector<std::string>& tokens);
     void DoSkill(const std::vector<std::string>& tokens);
@@ -44,6 +48,7 @@ private:
     void DoCombatSpell(const std::vector<std::string>& tokens);
 
     void ToggleCreep();
+    void SetRest(bool resting);
     void PrintBriefLook();
 
     std::string* _output = nullptr;
@@ -60,7 +65,10 @@ private:
 
     // Expand these out into all non-transient character attributes and skills
     uint8_t _speed = 8;
+
+    // Expand these out into all character modes
     bool _inching = false;
+    bool _resting = false;
     bool _inCombat = false;
     /**
      * Hp/MaxHp, Mp/MaxMp, Sta/MaxSta

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -182,6 +182,8 @@ Direction GetDirection(const std::string& direction)
         return Direction::SOUTHWEST;
     else if (direction == "m" || direction == "move")
         return Direction::MOVE;
+    else if (direction == "tr" || direction == "travel")
+        return Direction::TRAVEL;
     return Direction::INVALID;
 }
 

--- a/src/World.h
+++ b/src/World.h
@@ -44,7 +44,8 @@ enum class Direction : uint8_t
     NORTHWEST = 6,
     SOUTHEAST = 7,
     SOUTHWEST = 8,
-    MOVE = 9
+    MOVE = 9,
+    TRAVEL = 10
 };
 
 struct Location


### PR DESCRIPTION
The `Game::ExecuteCycle` function is pretty gnarly with many cases. Must separately handle popping command and checking for character delay and trimming command for the in-game case and the logging in case.